### PR TITLE
[33기 박슬기] Add : write Header 기능 구현

### DIFF
--- a/src/components/Nav/SideDrawer.js
+++ b/src/components/Nav/SideDrawer.js
@@ -1,8 +1,16 @@
 import styled, { css } from 'styled-components';
+import Login from '../../pages/Login/Login';
 
-const SideDrawer = ({ navDrawer, closeDrawer }) => {
+const SideDrawer = ({
+  loginModal,
+  startLogin,
+  quitLogin,
+  navDrawer,
+  closeDrawer,
+}) => {
   return (
     <>
+      {loginModal && <Login quitLogin={quitLogin} />}
       <DrawerBar drawerState={navDrawer}>
         <DrawerHeader>
           <ProfileImg>
@@ -14,7 +22,9 @@ const SideDrawer = ({ navDrawer, closeDrawer }) => {
             what you imagine
             <div>- King God Kyeom -</div>
           </ProfileText>
-          <HeaderLoginBtn>브랜치타임 시작하기</HeaderLoginBtn>
+          <HeaderLoginBtn onClick={startLogin}>
+            브랜치타임 시작하기
+          </HeaderLoginBtn>
         </DrawerHeader>
         <DrawerBody>
           <button>브런치 홈</button>
@@ -61,7 +71,7 @@ const DrawerBar = styled.div`
   font-size: 14px;
   text-align: center;
   transition: 800ms;
-  z-index: 100;
+  z-index: 1100;
 
   ${props =>
     props.drawerState &&

--- a/src/pages/write/Write.js
+++ b/src/pages/write/Write.js
@@ -1,34 +1,125 @@
-import React from 'react';
 import MDEditor from '@uiw/react-md-editor';
-import { ImFilePicture } from 'react-icons/im';
 import { FaBreadSlice } from 'react-icons/fa';
-import { BiAlignMiddle } from 'react-icons/bi';
-import styled from 'styled-components';
+import { RiDeleteBin2Line } from 'react-icons/ri';
+import { BiAlignMiddle, BiAlignLeft, BiImages } from 'react-icons/bi';
+import { AiOutlineArrowRight, AiOutlineArrowLeft } from 'react-icons/ai';
+import React, { useState, useEffect } from 'react';
+import styled, { css } from 'styled-components';
 
 const Write = () => {
   const [value, setValue] = React.useState(
     '# Hello world! <br> 내용을 입력하세요'
   );
 
+  const [titleAlign, setTitleAlign] = useState(true);
+  const [onImgMode, setOnImgMode] = useState(false);
+  const [headerColorMode, setHeaderColorMode] = useState(false);
+  const [headerColor, setHeaderColor] = useState(0);
+
+  const handleAlign = () => {
+    setTitleAlign(prev => !prev);
+  };
+
+  const handleHeaderColor = () => {
+    setHeaderColorMode(prev => !prev);
+    setOnImgMode(false);
+  };
+
+  const nextColor = () => {
+    setHeaderColor(prevHeaderColor => prevHeaderColor + 1);
+  };
+
+  const prevColor = () => {
+    setHeaderColor(prevHeaderColor => prevHeaderColor - 1);
+  };
+
+  const calculateColor = Math.abs(headerColor % 5);
+  const COLOR_SET = {
+    0: '#173f5f',
+    1: '#20639b',
+    2: '#3caea3',
+    3: '#f6d55a',
+    4: '#ed553b',
+  };
+
+  const [file, setFile] = useState('');
+  const [previewURL, setPreviewURL] = useState('');
+
+  useEffect(() => {
+    if (file !== '') setPreviewURL(' (reader.result) ');
+  }, [file]);
+
+  const handleFileOnChange = e => {
+    e.preventDefault();
+
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    const formData = new FormData();
+
+    formData.append('files', setFile);
+    setFile(file);
+
+    reader.onload = () => {
+      setPreviewURL(reader.result);
+      setOnImgMode(true);
+      setHeaderColorMode(false);
+    };
+
+    if (file) reader.readAsDataURL(file);
+  };
+
+  const removeImg = () => {
+    setOnImgMode(false);
+  };
+
   return (
     <>
-      <EditorHeader>
+      <EditorHeader
+        headerColorMode={headerColorMode}
+        setColor={COLOR_SET[calculateColor]}
+        previewURL={previewURL}
+        onImgMode={onImgMode}
+      >
         <HeaderWrapper>
-          <InputTitle>
+          <InputTitle changeAlign={titleAlign}>
             <BigTitle placeholder="제목을 입력하세요" />
             <SmallTitle placeholder="소제목을 입력하세요" />
           </InputTitle>
           <EditHeaderBtn>
-            <button>
-              <ImFilePicture />
-            </button>
-            <button>
+            <form>
+              <label>
+                <BiImages />
+                <input
+                  type="file"
+                  name="image"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  onChange={handleFileOnChange}
+                />
+              </label>
+            </form>
+            <button onClick={handleHeaderColor}>
               <FaBreadSlice />
             </button>
-            <button>
-              <BiAlignMiddle />
+            <button onClick={handleAlign}>
+              {titleAlign ? <BiAlignLeft /> : <BiAlignMiddle />}
             </button>
+            {onImgMode && (
+              <button onClick={removeImg}>
+                <RiDeleteBin2Line />
+              </button>
+            )}
           </EditHeaderBtn>
+          {headerColorMode && (
+            <HeaderColorBtn>
+              <button onClick={nextColor}>
+                <AiOutlineArrowLeft />
+              </button>
+              <button onClick={prevColor}>
+                <AiOutlineArrowRight />
+              </button>
+            </HeaderColorBtn>
+          )}
         </HeaderWrapper>
       </EditorHeader>
       <MDEditorWrapper data-color-mode="light">
@@ -38,7 +129,7 @@ const Write = () => {
           hideToolbar={true}
           enableScroll={true}
           visibleDragbar={false}
-          height={1000}
+          height={800}
         />
       </MDEditorWrapper>
     </>
@@ -48,16 +139,16 @@ const Write = () => {
 export default Write;
 
 const MDEditorWrapper = styled.div`
-  margin: 0 15%;
+  margin: 0 24% 5% 24%;
 `;
 
 const BigTitle = styled.input`
   font-size: 50px;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 `;
 
 const SmallTitle = styled.input`
-  font-size: large;
+  font-size: medium;
   font-weight: 300;
 `;
 
@@ -65,47 +156,130 @@ const EditHeaderBtn = styled.div`
   ${({ theme }) => theme.flex.flexBox('column')}
   position: absolute;
   right: 0;
+`;
 
-  button {
-    background: transparent;
-    border: 0;
-    font-size: x-large;
-    margin-bottom: 1rem;
-    cursor: pointer;
-    color: #999;
-
-    &:hover {
-      color: ${theme => theme.theme.colors.mint};
-    }
-  }
+const HeaderColorBtn = styled.div`
+  ${({ theme }) => theme.flex.flexBox('', '', 'space-between')}
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  margin-bottom: 0.5rem;
 `;
 
 const InputTitle = styled.div`
   ${({ theme }) => theme.flex.flexBox('column')}
   position: absolute;
+
+  input {
+    -webkit-appearance: none;
+
+    ::placeholder {
+      color: white;
+    }
+
+    background: transparent;
+    outline: none;
+    border: 0;
+    text-align: center;
+    caret-color: white;
+    color: white;
+  }
+
+  ${props =>
+    props.changeAlign &&
+    css`
+      left: 0;
+      bottom: 0;
+      margin-bottom: 6rem;
+      align-items: flex-start;
+      margin-left: 8%;
+
+      input {
+        text-align: left;
+      }
+    `}
 `;
 
 const HeaderWrapper = styled.div`
   ${({ theme }) => theme.flex.flexBox}
   position: relative;
   height: 100%;
-  width: 70%;
+  margin: 0 19%;
 `;
 
 const EditorHeader = styled.header`
-  ${({ theme }) => theme.flex.flexBox}
+  width: 100vw;
   height: 40vh;
-  text-align: center;
+  transition: 300ms;
+  margin-bottom: 3rem;
 
-  input {
-    -webkit-appearance: none;
-
-    text-align: center;
-    outline: none;
+  button,
+  form {
+    background: transparent;
     border: 0;
+    font-size: 24px;
+    margin-bottom: 1rem;
+    cursor: pointer;
+    color: white;
 
-    ::placeholder {
-      color: #ccc;
+    &:hover {
+      color: white;
+      opacity: 0.5;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
     }
   }
+
+  input {
+    ::placeholder {
+      opacity: 0.6;
+    }
+  }
+
+  ${({ previewURL }) => css`
+    background-image: url(${previewURL});
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+  `}
+
+  ${props =>
+    !props.onImgMode &&
+    css`
+      background-image: url('');
+    `}
+
+  ${({ setColor }) => css`
+    background-color: ${setColor};
+  `}
+
+  ${props =>
+    !props.headerColorMode &&
+    css`
+      margin-bottom: 0;
+      background-color: white;
+      transition: 500ms;
+
+      input {
+        caret-color: #ccc;
+        color: black;
+
+        ::placeholder {
+          color: #ccc;
+          opacity: 1;
+        }
+      }
+
+      button,
+      form {
+        color: #999;
+
+        &:hover {
+          color: ${({ theme }) => theme.colors.mint};
+          opacity: 1;
+        }
+      }
+    `}
 `;


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
**write 페이지의 Header 부분 기능을 구현**
1. Header 배경 이미지 삽입
2. Header 색상 변경
3. Title align 변경

<br />

## :: 구현 사항 설명
**1. Header 배경 이미지 삽입 & 삭제**
- Form Data를 이용한 input file 적용


**2. Header 색상 변경**
- Header Color Mode의 on/off 에 따라 컬러 변경 버튼 노출 / 비노출
- state를 사용하여 nextColor, prevColor에 숫자 부여
- 색상 값 목데이터 id에 따라 해당 색상으로 변경
- Math.abs()로 음수는 정수로 변환
- 목데이터에 지정된 색상 값 갯수만큼 버튼을 통해 입력 된 state 값을 나누고, 나눠 떨어진 값을 출력하는 함수 구현
- Color Number Calculate 함수를 통해  색상 변경 무한으로 가능하게 구현

**3. Title align 변경**
- useState를 활용하여 버튼 클릭 시 현재 상태의 반대로 align 변경
- state에 따라 노출 아이콘 삼항연산자 구현
<br />

## :: 성장 포인트
- 나눠 떨어진 값을 이용해 무한으로 컬러 변경이 가능하게 구현하는 것이 재밌고 뿌듯했습니다. 얏호 😄

<br />

## :: 기타 질문 및 특이 사항
- 더 효율적인 방법이 있을지 궁금합니다.

<br />